### PR TITLE
Use VAR=value to set implicit variables in Makefile

### DIFF
--- a/solo5-bindings/Makefile
+++ b/solo5-bindings/Makefile
@@ -1,7 +1,7 @@
 OPAM_DIR=$(shell opam config var prefix)
 
 FREESTANDING_CFLAGS=$(shell PKG_CONFIG_PATH=$(OPAM_DIR)/lib/pkgconfig pkg-config ocaml-freestanding --cflags)
-CC?=cc
+CC=cc
 CFLAGS=-O2 -g -Wall -Werror $(FREESTANDING_CFLAGS)
 
 OBJS=\


### PR DESCRIPTION
VAR?=value does not do what we thought it did.