### PR TITLE
Cleanup and remove verbosity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
         - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
         - TESTS=false
     matrix:
+        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-ukvm"
+        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.02 EXTRA_DEPS="solo5-kernel-ukvm"

--- a/lib/bindings/alloc_pages_stubs.c
+++ b/lib/bindings/alloc_pages_stubs.c
@@ -41,7 +41,7 @@ caml_alloc_pages(value did_gc, value n_pages)
   void* block = malloc(len);
   if (block == NULL) {
     if (Bool_val(did_gc))
-      printf("Io_page: memalign(%d, %zu) failed, even after GC.\n", PAGE_SIZE, len);
+      printf("ERROR: Io_page: memalign(%d, %zu) failed, even after GC.\n", PAGE_SIZE, len);
     caml_raise_out_of_memory();
   }
   /* Explicitly zero the page before returning it */

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -16,8 +16,6 @@
 
 #include "solo5.h"
 
-#include <stdio.h>
-
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/callback.h>
@@ -51,8 +49,6 @@ caml_get_cmdline(value unit)
 
 int solo5_app_main(char *cmdline)
 {
-    printf("Solo5: new bindings\n");
-
     solo5_cmdline = cmdline;
     caml_startup(unused_argv);
 

--- a/lib/bindings/mm_stubs.c
+++ b/lib/bindings/mm_stubs.c
@@ -17,6 +17,7 @@
 #include "solo5.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <caml/mlvalues.h>
 
@@ -24,16 +25,14 @@ CAMLprim value
 stub_heap_get_pages_total(__attribute__((unused)) value unit) // noalloc
 {
 	//return Val_long(minios_heap_pages_total);
-	printf("STUB: %s unimplemented, aborting", __func__);
-        solo5_exit();
-	return Val_long(0);
+	printf("STUB: %s unimplemented, aborting\n", __func__);
+        abort();
 }
 
 CAMLprim value
 stub_heap_get_pages_used(__attribute__((unused)) value unit) // noalloc
 {
 	//return Val_long(minios_heap_pages_used);
-	printf("STUB: %s unimplemented, aborting", __func__);
-        solo5_exit();
-	return Val_long(0);
+	printf("STUB: %s unimplemented, aborting\n", __func__);
+        abort();
 }

--- a/lib/bindings/solo5_block_stubs.c
+++ b/lib/bindings/solo5_block_stubs.c
@@ -27,7 +27,8 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
-CAMLprim value stub_blk_write(value sector, value buffer, value num)
+CAMLprim value
+stub_blk_write(value sector, value buffer, value num)
 {
     CAMLparam3(sector, buffer, num);
     uint64_t sec = Int64_val(sector);
@@ -40,7 +41,8 @@ CAMLprim value stub_blk_write(value sector, value buffer, value num)
     CAMLreturn(Val_bool(!ret));
 }
 
-CAMLprim value stub_blk_read(value sector, value buffer, value num)
+CAMLprim value
+stub_blk_read(value sector, value buffer, value num)
 {
     CAMLparam3(sector, buffer, num);
     uint64_t sec = Int64_val(sector);
@@ -53,19 +55,22 @@ CAMLprim value stub_blk_read(value sector, value buffer, value num)
     CAMLreturn(Val_bool(!ret));
 }
 
-CAMLprim value stub_blk_sector_size(value unit)
+CAMLprim value
+stub_blk_sector_size(value unit)
 {
     CAMLparam1(unit);
     CAMLreturn(Val_int(solo5_blk_sector_size()));
 }
 
-CAMLprim value stub_blk_sectors(value unit)
+CAMLprim value
+stub_blk_sectors(value unit)
 {
     CAMLparam1(unit);
     CAMLreturn(caml_copy_int64(solo5_blk_sectors()));
 }
 
-CAMLprim value stub_blk_rw(value unit)
+CAMLprim value
+stub_blk_rw(value unit)
 {
     CAMLparam1(unit);
     CAMLreturn(Val_bool(solo5_blk_rw()));

--- a/lib/bindings/solo5_block_stubs.c
+++ b/lib/bindings/solo5_block_stubs.c
@@ -19,7 +19,6 @@
 #include "solo5.h"
 
 #include <assert.h>
-#include <stdio.h>
 
 #include <caml/alloc.h>
 #include <caml/memory.h>
@@ -28,75 +27,46 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
-CAMLprim value stub_blk_write(value sector, value buffer, value num) {
+CAMLprim value stub_blk_write(value sector, value buffer, value num)
+{
     CAMLparam3(sector, buffer, num);
     uint64_t sec = Int64_val(sector);
     uint8_t *data = Caml_ba_data_val(buffer);
     int n = Int_val(num);
-    int ret = 0;
+    int ret;
 
     assert(Caml_ba_array_val(buffer)->num_dims == 1);
-	
-    //printf("Solo5 blk write: sec=%d num=%d\n", sec, n);
-
     ret = solo5_blk_write_sync(sec, data, n);
-    if ( ret ) 
-        printf("blk write failed... %d to sector=%d\n", n, sec);
-
-#if 0
-    {
-        int i;
-        for (i = 0; i < n; i++) {
-            printf("%02x ", (uint8_t) data[i]);
-            if ( i % 16 == 15 )
-                printf("\n");
-        }
-        printf("\n");
-    }
-#endif
-
     CAMLreturn(Val_bool(!ret));
 }
 
-CAMLprim value stub_blk_read(value sector, value buffer, value num) {
+CAMLprim value stub_blk_read(value sector, value buffer, value num)
+{
     CAMLparam3(sector, buffer, num);
     uint64_t sec = Int64_val(sector);
     uint8_t *data = Caml_ba_data_val(buffer);
     int n = Int_val(num);
-    int ret = 0;
+    int ret;
 
     assert(Caml_ba_array_val(buffer)->num_dims == 1);
-
-    //printf("Solo5 blk read: sec=%d num=%d\n", sec, n);
-
     ret = solo5_blk_read_sync(sec, data, &n);
-    if ( ret )
-        printf("virtio read failed... %d from sector=%d\n", n, sec);
-
-#if 0
-    {
-        int i;
-        for (i = 0; i < n; i++) {
-            printf("%02x ", (uint8_t) data[i]);
-            if ( i % 16 == 15 )
-                printf("\n");
-        }
-        printf("\n");
-    }
-#endif
-
     CAMLreturn(Val_bool(!ret));
 }
 
-CAMLprim value stub_blk_sector_size(value unit) {
+CAMLprim value stub_blk_sector_size(value unit)
+{
     CAMLparam1(unit);
     CAMLreturn(Val_int(solo5_blk_sector_size()));
 }
-CAMLprim value stub_blk_sectors(value unit) {
+
+CAMLprim value stub_blk_sectors(value unit)
+{
     CAMLparam1(unit);
     CAMLreturn(caml_copy_int64(solo5_blk_sectors()));
 }
-CAMLprim value stub_blk_rw(value unit) {
+
+CAMLprim value stub_blk_rw(value unit)
+{
     CAMLparam1(unit);
     CAMLreturn(Val_bool(solo5_blk_rw()));
 }

--- a/lib/bindings/solo5_console_stubs.c
+++ b/lib/bindings/solo5_console_stubs.c
@@ -25,7 +25,8 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
-CAMLprim value stub_console_write(value arg)
+CAMLprim value
+stub_console_write(value arg)
 {
     CAMLparam1(arg);
 

--- a/lib/bindings/solo5_console_stubs.c
+++ b/lib/bindings/solo5_console_stubs.c
@@ -18,8 +18,6 @@
 
 #include "solo5.h"
 
-#include <string.h>
-
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -27,12 +25,10 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
-
-CAMLprim value stub_console_write(value arg) {
+CAMLprim value stub_console_write(value arg)
+{
     CAMLparam1(arg);
 
-    const char *str = String_val(arg);
-    solo5_console_write(str, strlen(str));
-
+    solo5_console_write(String_val(arg), caml_string_length(arg));
     CAMLreturn(Val_unit);
 }

--- a/lib/bindings/solo5_net_stubs.c
+++ b/lib/bindings/solo5_net_stubs.c
@@ -27,12 +27,14 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
-CAMLprim value stub_net_mac(value unit) {
+CAMLprim value stub_net_mac(value unit)
+{
     CAMLparam1(unit);
     CAMLreturn(caml_copy_string(solo5_net_mac_str()));
 }
 
-CAMLprim value stub_net_read(value buffer, value num) {
+CAMLprim value stub_net_read(value buffer, value num)
+{
     CAMLparam2(buffer, num);
     uint8_t *data = Caml_ba_data_val(buffer);
     int n = Int_val(num);
@@ -41,13 +43,14 @@ CAMLprim value stub_net_read(value buffer, value num) {
     assert(Caml_ba_array_val(buffer)->num_dims == 1);
     
     ret = solo5_net_read_sync(data, &n);
-    if ( ret )
+    if (ret != 0)
         CAMLreturn(Val_int(-1));
-    
-    CAMLreturn(Val_int(n));
+    else
+        CAMLreturn(Val_int(n));
 }
 
-CAMLprim value stub_net_write(value buffer, value num) {
+CAMLprim value stub_net_write(value buffer, value num)
+{
     CAMLparam2(buffer, num);
     uint8_t *data = Caml_ba_data_val(buffer);
     int n = Int_val(num);
@@ -56,8 +59,8 @@ CAMLprim value stub_net_write(value buffer, value num) {
     assert(Caml_ba_array_val(buffer)->num_dims == 1);
 
     ret = solo5_net_write_sync(data, n);
-    if ( ret )
+    if (ret != 0)
         CAMLreturn(Val_int(-1));
-
-    CAMLreturn(Val_int(n));
+    else
+        CAMLreturn(Val_int(n));
 }

--- a/lib/bindings/solo5_net_stubs.c
+++ b/lib/bindings/solo5_net_stubs.c
@@ -27,13 +27,15 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
-CAMLprim value stub_net_mac(value unit)
+CAMLprim value
+stub_net_mac(value unit)
 {
     CAMLparam1(unit);
     CAMLreturn(caml_copy_string(solo5_net_mac_str()));
 }
 
-CAMLprim value stub_net_read(value buffer, value num)
+CAMLprim value
+stub_net_read(value buffer, value num)
 {
     CAMLparam2(buffer, num);
     uint8_t *data = Caml_ba_data_val(buffer);
@@ -49,7 +51,8 @@ CAMLprim value stub_net_read(value buffer, value num)
         CAMLreturn(Val_int(n));
 }
 
-CAMLprim value stub_net_write(value buffer, value num)
+CAMLprim value
+stub_net_write(value buffer, value num)
 {
     CAMLparam2(buffer, num);
     uint8_t *data = Caml_ba_data_val(buffer);

--- a/lib/lifecycle.ml
+++ b/lib/lifecycle.ml
@@ -1,3 +1,3 @@
 (* No shutdown events on Solo5. *)
-let await_shutdown_request ?(can_poweroff:_) ?(can_reboot:_) () =
+let await_shutdown_request ?can_poweroff:_ ?can_reboot:_ () =
   fst (Lwt.wait ())

--- a/lib/mM.ml
+++ b/lib/mM.ml
@@ -1,4 +1,4 @@
 module Heap_pages = struct
-  external total: unit -> int = "stub_heap_get_pages_total" "noalloc"
-  external used: unit -> int = "stub_heap_get_pages_used" "noalloc"
+  external total: unit -> int = "stub_heap_get_pages_total" [@@noalloc]
+  external used: unit -> int = "stub_heap_get_pages_used" [@@noalloc]
 end

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -39,7 +39,7 @@ let rec call_hooks hooks  =
         let _ =
           Lwt.catch f
           (fun exn ->
-            Printf.printf "call_hooks: exn %s\n%!" (Printexc.to_string exn);
+            Printf.printf "ERROR: call_hooks(): Unhandled exception: %s\n%!" (Printexc.to_string exn);
             return ()) in
         call_hooks hooks
 

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -53,7 +53,7 @@ type sleep = {
 module SleepQueue =
   Lwt_pqueue.Make (struct
                      type t = sleep
-                     let compare { time = t1 } { time = t2 } = compare t1 t2
+                     let compare { time = t1; _ } { time = t2; _ } = compare t1 t2
                    end)
 
 (* Threads waiting for a timeout to expire: *)
@@ -85,10 +85,10 @@ let in_the_past now t =
 
 let rec restart_threads now =
   match SleepQueue.lookup_min !sleep_queue with
-    | Some{ canceled = true } ->
+    | Some{ canceled = true; _ } ->
         sleep_queue := SleepQueue.remove_min !sleep_queue;
         restart_threads now
-    | Some{ time = time; thread = thread } when in_the_past now time ->
+    | Some{ time = time; thread = thread; _ } when in_the_past now time ->
         sleep_queue := SleepQueue.remove_min !sleep_queue;
         Lwt.wakeup thread ();
         restart_threads now
@@ -106,10 +106,10 @@ let min_timeout a b = match a, b with
 
 let rec get_next_timeout () =
   match SleepQueue.lookup_min !sleep_queue with
-    | Some{ canceled = true } ->
+    | Some{ canceled = true; _ } ->
         sleep_queue := SleepQueue.remove_min !sleep_queue;
         get_next_timeout ()
-    | Some{ time = time } ->
+    | Some{ time = time; _ } ->
         Some time
     | None ->
         None


### PR DESCRIPTION
General cleanup of the `mirage-solo5` code. Removes the unnecessary `Solo5: new bindings` message, cleans up formatting of other aborts/errors.

I've also cleaned up some of the stubs (removing dead/unused/debug code) and fixed all the OCaml warnings with the exception of

````
File "lib/time.ml", line 54, characters 2-17:
Warning 3: deprecated: module Lwt_pqueue
 This module is an implementation detail of Lwt. See
   http://ocsigen.org/lwt/dev/api/Lwt_pqueue
````

Could someone with more OCaml/Lwt chops than me give this a quick review and verify that I've not broken anything? @hannesm / @samoht perhaps?