### PR TITLE
Update CHANGES.md for 0.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,3 @@ env:
         - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.02 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.02 EXTRA_DEPS="solo5-kernel-virtio"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 * Use [@@noalloc] rather than "noalloc"
 * Fix warnings, formatting and cleanup
-* Test with OCaml 4.04
+* Require OCaml 4.03
+* Test also with OCaml 4.04
 * Rename caml_{alloc_pages,get_addr} to mirage_{alloc_pages,get_addr}
   to avoid using the OCaml compiler namespace. This corresponds with
   [mirage/io-page#48]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## v0.2.1 (2017-06-15)
+
+* Use [@@noalloc] rather than "noalloc"
+* Fix warnings, formatting and cleanup
+* Test with OCaml 4.04
+* Rename caml_{alloc_pages,get_addr} to mirage_{alloc_pages,get_addr}
+  to avoid using the OCaml compiler namespace. This corresponds with
+  [mirage/io-page#48]
+
 ## v0.2.0 (2017-01-17)
 
 * Port to topkg (@mato, @hannesm, @yomimono, #15)

--- a/opam
+++ b/opam
@@ -23,4 +23,4 @@ depends: [
   "ocaml-freestanding"
   "logs"
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
This is a point release needed because the name of the Io_page C stubs have changed: previously they had the prefix "caml_", which as @yallop points out is reserved for the OCaml compiler. The new convention is a prefix of "mirage_".

See [mirage/io-page#48]

Signed-off-by: David Scott <dave@recoil.org>