### PR TITLE
in 0.2.1 (released 15th June 2017), the io-page stubs were renamed

### DIFF
--- a/opam
+++ b/opam
@@ -23,6 +23,9 @@ depends: [
   "ocaml-freestanding"
   "logs"
 ]
+conflicts: [
+  "io-page" {< "2.0.0"}
+]
 available: [
   ocaml-version >= "4.03.0" & (arch = "x86_64" | arch = "amd64" | arch = "aarch64")
 ]


### PR DESCRIPTION
caml_alloc_pages -> mirage_alloc_pages

this is working fine with any io-page >= 2.0.0, but earlier versions require
caml_alloc_pages, which is no longer present.  since io-page and mirage-solo5
don't depend in any way on each other, adding a conflict here appeared like a
sensible solution.  evidence was thanks to our mirage-skeleton cron builder at
https://api.travis-ci.org/v3/job/317650589/log.txt