### PR TITLE
opam, Travis: Switch to Solo5 master for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
     global:
-        - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+        - EXTRA_REMOTES="https://github.com/Solo5/opam-solo5.git"
         - TESTS=false
     matrix:
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-ukvm"
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-virtio"
+        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-ukvm"
+        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-virtio"

--- a/opam
+++ b/opam
@@ -20,12 +20,9 @@ depends: [
   "ocb-stubblr" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "ocaml-freestanding"
+  "ocaml-freestanding" {>= "0.3.0"}
   "logs"
+  ("solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} | "solo5-kernel-muen" {>= "0.3.0"})
 ]
-conflicts: [
-  "io-page" {< "2.0.0"}
-]
-available: [
-  ocaml-version >= "4.03.0" & (arch = "x86_64" | arch = "amd64" | arch = "aarch64")
-]
+conflicts: [ "io-page" {< "2.0.0"} ]
+available: [ ocaml-version >= "4.04.2" ]


### PR DESCRIPTION
- Restrict availability to OCaml 4.04.2 and newer as per mirage list
consensus
- Update build matrix
- Use Solo5/opam-solo5 to build against Solo5 master
~~- Switch Travis to container-based environment, now that a trusty one is available and we don't need sudo here~~