### PR TITLE
Adapt to Solo5 API changes, refactor stubs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,9 +3,9 @@ Copyright (C) 2005-2008 Jérôme Vouillon
 Copyright (c) 2010-2012 Anil Madhavapeddy <anil@recoil.org>
 Copyright (c) 2012 Pierre Chambart
 Copyright (c) 2012, 2013 Citrix Inc
-Copyright (c) 2016 Martin Lucina <martin.lucina@docker.com>
 Copyright (c) 2015 Thomas Leonard <talex5@gmail.com>
 Copyright (c) 2015, IBM
+Copyright (c) 2016-2018 Martin Lucina <martin@lucina.net>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -26,34 +26,30 @@ static char *unused_argv[] = { "mirage", NULL };
 static const char *solo5_cmdline = "";
 
 CAMLprim value
-caml_poll(value v_until)
+mirage_solo5_yield(value v_deadline)
 {
-    CAMLparam1(v_until);
-    CAMLlocal1(work_to_do);
+    CAMLparam1(v_deadline);
 
-    uint64_t until = (Int64_val(v_until));
-    int rc = solo5_poll(until);
+    solo5_time_t deadline = (Int64_val(v_deadline));
+    bool rc = solo5_yield(deadline);
 
-    work_to_do = Val_bool(rc);
-    CAMLreturn(work_to_do);
+    CAMLreturn(Val_bool(rc));
 }
 
 CAMLprim value
-caml_get_cmdline(value unit)
+mirage_solo5_get_cmdline(value unit)
 {
     CAMLparam1(unit);
-    CAMLlocal1(result);
 
-    result = caml_copy_string(solo5_cmdline);
-    CAMLreturn(result);
+    CAMLreturn(caml_copy_string(solo5_cmdline));
 }
 
 extern void _nolibc_init(uintptr_t, size_t);
 
-int solo5_app_main(const struct solo5_boot_info *bi)
+int solo5_app_main(const struct solo5_start_info *si)
 {
-    solo5_cmdline = bi->cmdline;
-    _nolibc_init(bi->heap_start, bi->heap_size);
+    solo5_cmdline = si->cmdline;
+    _nolibc_init(si->heap_start, si->heap_size);
     caml_startup(unused_argv);
 
     return 0;

--- a/lib/bindings/solo5_block_stubs.c
+++ b/lib/bindings/solo5_block_stubs.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2015, IBM 
- * Author(s): Dan Williams <djwillia@us.ibm.com> 
+/* Copyright (c) 2015, IBM
+ * Author(s): Dan Williams <djwillia@us.ibm.com>
  *
  * Permission to use, copy, modify, and/or distribute this software
  * for any purpose with or without fee is hereby granted, provided
@@ -18,8 +18,7 @@
 
 #include "solo5.h"
 
-#include <assert.h>
-
+#define CAML_NAME_SPACE
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -28,50 +27,42 @@
 #include <caml/bigarray.h>
 
 CAMLprim value
-stub_blk_write(value sector, value buffer, value num)
+mirage_solo5_block_info(value v_unit)
 {
-    CAMLparam3(sector, buffer, num);
-    uint64_t sec = Int64_val(sector);
-    uint8_t *data = Caml_ba_data_val(buffer);
-    int n = Int_val(num);
-    int ret;
+    CAMLparam1(v_unit);
+    CAMLlocal1(v_result);
+    struct solo5_block_info bi;
 
-    assert(Caml_ba_array_val(buffer)->num_dims == 1);
-    ret = solo5_blk_write_sync(sec, data, n);
-    CAMLreturn(Val_bool(!ret));
+    solo5_block_info(&bi);
+    v_result = caml_alloc(2, 0);
+    Store_field(v_result, 0, caml_copy_int64(bi.capacity));
+    Store_field(v_result, 1, caml_copy_int64(bi.block_size));
+
+    CAMLreturn(v_result);
 }
 
 CAMLprim value
-stub_blk_read(value sector, value buffer, value num)
+mirage_solo5_block_read(value v_offset, value v_buf, value v_size)
 {
-    CAMLparam3(sector, buffer, num);
-    uint64_t sec = Int64_val(sector);
-    uint8_t *data = Caml_ba_data_val(buffer);
-    int n = Int_val(num);
-    int ret;
+    CAMLparam3(v_offset, v_buf, v_size);
+    solo5_off_t offset = Int64_val(v_offset);
+    uint8_t *buf = Caml_ba_data_val(v_buf);
+    size_t size = Long_val(v_size);
+    solo5_result_t result;
 
-    assert(Caml_ba_array_val(buffer)->num_dims == 1);
-    ret = solo5_blk_read_sync(sec, data, &n);
-    CAMLreturn(Val_bool(!ret));
+    result = solo5_block_read(offset, buf, size);
+    CAMLreturn(Val_int(result));
 }
 
 CAMLprim value
-stub_blk_sector_size(value unit)
+mirage_solo5_block_write(value v_offset, value v_buf, value v_size)
 {
-    CAMLparam1(unit);
-    CAMLreturn(Val_int(solo5_blk_sector_size()));
-}
+    CAMLparam3(v_offset, v_buf, v_size);
+    solo5_off_t offset = Int64_val(v_offset);
+    const uint8_t *buf = Caml_ba_data_val(v_buf);
+    size_t size = Long_val(v_size);
+    solo5_result_t result;
 
-CAMLprim value
-stub_blk_sectors(value unit)
-{
-    CAMLparam1(unit);
-    CAMLreturn(caml_copy_int64(solo5_blk_sectors()));
-}
-
-CAMLprim value
-stub_blk_rw(value unit)
-{
-    CAMLparam1(unit);
-    CAMLreturn(Val_bool(solo5_blk_rw()));
+    result = solo5_block_write(offset, buf, size);
+    CAMLreturn(Val_int(result));
 }

--- a/lib/bindings/solo5_console_stubs.c
+++ b/lib/bindings/solo5_console_stubs.c
@@ -18,6 +18,7 @@
 
 #include "solo5.h"
 
+#define CAML_NAME_SPACE
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -26,10 +27,12 @@
 #include <caml/bigarray.h>
 
 CAMLprim value
-stub_console_write(value arg)
+mirage_solo5_console_write(value v_buf, value v_size)
 {
-    CAMLparam1(arg);
+    CAMLparam2(v_buf, v_size);
+    const char *buf = Caml_ba_data_val(v_buf);
+    size_t size = Long_val(v_size);
 
-    solo5_console_write(String_val(arg), caml_string_length(arg));
+    solo5_console_write(buf, size);
     CAMLreturn(Val_unit);
 }

--- a/lib/bindings/solo5_net_stubs.c
+++ b/lib/bindings/solo5_net_stubs.c
@@ -37,7 +37,11 @@ mirage_solo5_net_info(value v_unit)
 
     solo5_net_info(&ni);
     v_mac_address = caml_alloc_string(SOLO5_NET_ALEN);
+#if defined(Bytes_val)
     memcpy(Bytes_val(v_mac_address), ni.mac_address, SOLO5_NET_ALEN);
+#else
+    memcpy(String_val(v_mac_address), ni.mac_address, SOLO5_NET_ALEN);
+#endif
     v_result = caml_alloc(2, 0);
     Store_field(v_result, 0, v_mac_address);
     Store_field(v_result, 1, Val_long(ni.mtu));

--- a/lib/bindings/solo5_net_stubs.c
+++ b/lib/bindings/solo5_net_stubs.c
@@ -18,8 +18,9 @@
 
 #include "solo5.h"
 
-#include <assert.h>
+#include <string.h>
 
+#define CAML_NAME_SPACE
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -28,42 +29,47 @@
 #include <caml/bigarray.h>
 
 CAMLprim value
-stub_net_mac(value unit)
+mirage_solo5_net_info(value v_unit)
 {
-    CAMLparam1(unit);
-    CAMLreturn(caml_copy_string(solo5_net_mac_str()));
+    CAMLparam1(v_unit);
+    CAMLlocal2(v_mac_address, v_result);
+    struct solo5_net_info ni;
+
+    solo5_net_info(&ni);
+    v_mac_address = caml_alloc_string(SOLO5_NET_ALEN);
+    memcpy(Bytes_val(v_mac_address), ni.mac_address, SOLO5_NET_ALEN);
+    v_result = caml_alloc(2, 0);
+    Store_field(v_result, 0, v_mac_address);
+    Store_field(v_result, 1, Val_long(ni.mtu));
+
+    CAMLreturn(v_result);
 }
 
 CAMLprim value
-stub_net_read(value buffer, value num)
+mirage_solo5_net_read(value v_buf, value v_size)
 {
-    CAMLparam2(buffer, num);
-    uint8_t *data = Caml_ba_data_val(buffer);
-    int n = Int_val(num);
-    int ret;
+    CAMLparam2(v_buf, v_size);
+    CAMLlocal1(v_result);
+    uint8_t *buf = Caml_ba_data_val(v_buf);
+    size_t size = Long_val(v_size);
+    size_t read_size;
+    solo5_result_t result;
     
-    assert(Caml_ba_array_val(buffer)->num_dims == 1);
-    
-    ret = solo5_net_read_sync(data, &n);
-    if (ret != 0)
-        CAMLreturn(Val_int(-1));
-    else
-        CAMLreturn(Val_int(n));
+    result = solo5_net_read(buf, size, &read_size);
+    v_result = caml_alloc_tuple(2);
+    Field(v_result, 0) = Val_int(result);
+    Field(v_result, 1) = Val_long(read_size);
+    CAMLreturn(v_result);
 }
 
 CAMLprim value
-stub_net_write(value buffer, value num)
+mirage_solo5_net_write(value v_buf, value v_size)
 {
-    CAMLparam2(buffer, num);
-    uint8_t *data = Caml_ba_data_val(buffer);
-    int n = Int_val(num);
-    int ret;
+    CAMLparam2(v_buf, v_size);
+    const uint8_t *buf = Caml_ba_data_val(v_buf);
+    size_t size = Long_val(v_size);
+    solo5_result_t result;
 
-    assert(Caml_ba_array_val(buffer)->num_dims == 1);
-
-    ret = solo5_net_write_sync(data, n);
-    if (ret != 0)
-        CAMLreturn(Val_int(-1));
-    else
-        CAMLreturn(Val_int(n));
+    result = solo5_net_write(buf, size);
+    CAMLreturn(Val_int(result));
 }

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -23,7 +23,7 @@
 
 open Lwt
 
-external poll : [`Time] Time.Monotonic.t -> bool = "caml_poll"
+external solo5_yield : [`Time] Time.Monotonic.t -> bool = "mirage_solo5_yield"
 
 let exit_hooks = Lwt_sequence.create ()
 let enter_hooks = Lwt_sequence.create ()
@@ -46,7 +46,7 @@ let rec call_hooks hooks  =
 (* Solo5 currently has an all-or-nothing interface to block and wait for I/O
  * events, so we use a single condition variable to block threads which are
  * waiting for work and wake them all up if I/O is possible.  This will need to
- * be extended once solo5_poll() gains support for selecting events of
+ * be extended once solo5_yield() gains support for selecting events of
  * interest. *)
 let work = Lwt_condition.create ()
 let wait_for_work () = Lwt_condition.wait work
@@ -70,7 +70,7 @@ let run t =
           |None -> Time.Monotonic.(time () + of_nanoseconds 86_400_000_000_000L) (* one day = 24 * 60 * 60 s *)
           |Some tm -> tm
         in
-        if poll timeout then begin
+        if solo5_yield timeout then begin
           (* Call enter hooks. *)
           Lwt_sequence.iter_l (fun f -> f ()) enter_iter_hooks;
           (* Some I/O is possible, wake up threads and continue. *)

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -86,3 +86,14 @@ val with_timeout : int64 -> (unit -> 'a Lwt.t) -> 'a Lwt.t
     ]}
 *)
 end
+
+module Solo5 : sig
+
+type solo5_result =
+  | SOLO5_R_OK
+  | SOLO5_R_AGAIN
+  | SOLO5_R_EINVAL
+  | SOLO5_R_EUNSPEC
+(** A type mapping the C enum solo5_result_t to OCaml **)
+
+end

--- a/lib/oS.mlpack
+++ b/lib/oS.mlpack
@@ -2,4 +2,5 @@ Env
 Lifecycle
 Main
 MM
+Solo5
 Time

--- a/lib/solo5.ml
+++ b/lib/solo5.ml
@@ -1,0 +1,6 @@
+type solo5_result =
+  | SOLO5_R_OK
+  | SOLO5_R_AGAIN
+  | SOLO5_R_EINVAL
+  | SOLO5_R_EUNSPEC
+(** A type mapping the C enum solo5_result_t to OCaml **)


### PR DESCRIPTION
This adapts to Solo5 API changes in Solo5/solo5#245.

Additional refactoring in the OCaml/C stubs:

- Rename all Solo5-related C stubs into mirage_solo5_xxx namespace.
- Block and net stubs have been further refactored and "OCamlized".

This is intended to be reviewed in conjunction with PRs to mirage/mirage-{net,block,bootvar}-solo5 which depend on the C stub changes, I will open and link those shortly.

For ease of reviewing as diffs, I have not moved the refactored stubs into their respective packages; I plan to do this as a separate followup PR.