### PR TITLE
pass -custom to ocamlmklib

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true: bin_annot, safe_string, principal
+true: bin_annot, safe_string, principal, custom
 true: warn(A-44)
 
 <myocamlbuild.ml>: package(ocb-stubblr)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,4 +1,9 @@
 open Ocamlbuild_plugin
-open Ocb_stubblr
 
-let () = Ocamlbuild_plugin.dispatch Ocb_stubblr.init
+let () =
+  dispatch begin fun hook ->
+    Ocb_stubblr.init hook ;
+    match hook with
+    | After_rules -> flag [ "ocamlmklib" ; "custom" ] & A "-custom"
+    | _ -> ()
+  end


### PR DESCRIPTION
same as i did in mirage-xen, this may fix the `-fno-pie` issue mentioned in  https://github.com/mirage/mirage-solo5/pull/15 and https://github.com/Solo5/solo5/commit/e8b44b5d6bcf4eaff2f386e2adb04ff0ffbc739a#diff-735003ab6f5797c8b8bdecbbbb9322a8 //cc @adamsteen @mato