### PR TITLE
Porting ukvm to OpenBSD vmm APIs

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true: bin_annot, safe_string, principal
+true: bin_annot, safe_string, principal, custom
 true: warn(A-44)
 
 <myocamlbuild.ml>: package(ocb-stubblr)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,4 +1,9 @@
 open Ocamlbuild_plugin
-open Ocb_stubblr
 
-let () = Ocamlbuild_plugin.dispatch Ocb_stubblr.init
+let () =
+  dispatch begin fun hook ->
+    Ocb_stubblr.init hook ;
+    match hook with
+    | After_rules -> flag [ "ocamlmklib" ; "custom" ] & A "-custom"
+    | _ -> ()
+  end

--- a/opam
+++ b/opam
@@ -12,7 +12,10 @@ authors: [
 tags: [
   "org:mirage"
 ]
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+build: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ] { os != "openbsd" }
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "false" ] { os = "openbsd" }
+]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
workaround 'pkg.ml no VCS repo found' and pass -custom to ocamlmklib