### PR TITLE
Update for Solo5 0.4.0 renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     global:
         - TESTS=false
     matrix:
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-virtio"
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-muen"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-virtio"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-muen"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ env:
     global:
         - TESTS=false
     matrix:
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-muen"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-muen"
-        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-muen"
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-virtio"
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-muen"
+        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-virtio"
+        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-muen"
+        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-bindings-virtio"
+        - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-bindings-muen"

--- a/opam
+++ b/opam
@@ -23,9 +23,17 @@ depends: [
   "ocb-stubblr" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "ocaml-freestanding" {>= "0.3.0"}
+  "ocaml-freestanding" {>= "0.4.0"}
   "logs"
-  ("solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} | "solo5-kernel-muen" {>= "0.3.0"})
+  ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen")
 ]
-conflicts: [ "io-page" {< "2.0.0"} ]
+conflicts: [
+  "io-page" {< "2.0.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
 available: [ ocaml-version >= "4.04.2" ]
+post-messages: [
+  "As of MirageOS 3.2.0 / Solo5 0.4.0, the 'ukvm' target has been renamed to 'hvt'. Please refer to https://github.com/mirage/mirage/blob/master/CHANGES.md for further details on this change."
+]


### PR DESCRIPTION
As of Solo5 0.4.0, the Solo5 OPAM packages have been renamed. This
updates mirage-solo5 to use the new package names, and conflict with the
old packages.

A post-installation message informing about the primary end-user change
("ukvm" target renamed to "hvt") has been added to "opam".