### PR TITLE
opam: Bump ocaml-freestanding dependency to >= 0.4.1

### DIFF
--- a/opam
+++ b/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "ocaml-freestanding" {>= "0.4.0"}
+  "ocaml-freestanding" {>= "0.4.1"}
   "logs"
   ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
 ]


### PR DESCRIPTION
This is mainly for Genode to ensure that the non-contiguous memory fix
is in place.