### PR TITLE
install mirage-solo5.pc to lib/pkconfig (instead of share/pkgconfig)

### DIFF
--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build & >= "0.7.6"}
+  "topkg" {build & >= "0.9.0"}
   "ocb-stubblr" {build}
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "1.0.1"}

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -16,6 +16,5 @@ let () =
   Ok [
     Pkg.mllib "lib/oS.mllib" ;
     Pkg.clib ~dllfield:nowhere "lib/libmirage-solo5_bindings.clib";
-    (* Should be lib/pkgconfig/ but workaround ocaml/opam#2153 *)
-    Pkg.share_root ~dst:"pkgconfig/" "lib/bindings/mirage-solo5.pc"
+    Pkg.lib_root ~dst:"pkgconfig/" "lib/bindings/mirage-solo5.pc"
   ]


### PR DESCRIPTION
this requires topkg 0.9.0 and opam2