### PR TITLE
Replace depreciated modules

### DIFF
--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true: bin_annot, safe_string, principal, custom
 true: warn(A-44)
 
 <myocamlbuild.ml>: package(ocb-stubblr)
-<lib/*>: package(lwt-dllist lwt cstruct logs)
+<lib/*>: package(bheap lwt-dllist lwt cstruct logs)
 <lib/*.cm{x,o}> and not <lib/oS.cmx>: for-pack(OS)
 <lib/bindings/*.c>: pkg-config(ocaml-freestanding)
 <lib/bindings/*.c> : ccopt(-O2 -std=c99 -Wall -Werror)

--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true: bin_annot, safe_string, principal, custom
 true: warn(A-44)
 
 <myocamlbuild.ml>: package(ocb-stubblr)
-<lib/*>: package(lwt cstruct logs)
+<lib/*>: package(lwt-dllist lwt cstruct logs)
 <lib/*.cm{x,o}> and not <lib/oS.cmx>: for-pack(OS)
 <lib/bindings/*.c>: pkg-config(ocaml-freestanding)
 <lib/bindings/*.c> : ccopt(-O2 -std=c99 -Wall -Werror)

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -90,6 +90,7 @@ let in_the_past now t =
 
 let rec restart_threads now =
   match SleepQueue.maximum sleep_queue with
+  | exception Binary_heap.Empty -> ()
   | { canceled = true; _ } ->
       SleepQueue.remove sleep_queue;
       restart_threads now
@@ -98,7 +99,6 @@ let rec restart_threads now =
       Lwt.wakeup thread ();
       restart_threads now
   | _ -> ()
-  | exception Not_found -> ()
 
 (* +-----------------------------------------------------------------+
    | Event loop                                                      |
@@ -111,12 +111,12 @@ let min_timeout a b = match a, b with
 
 let rec get_next_timeout () =
   match SleepQueue.maximum sleep_queue with
+  | exception Binary_heap.Empty -> None
   | { canceled = true; _ } ->
       SleepQueue.remove sleep_queue;
       get_next_timeout ()
   | { time = time; _ } ->
       Some time
-  | exception Not_found -> None
 
 let select_next () =
   (* Transfer all sleepers added since the last iteration to the main

--- a/opam
+++ b/opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
+  "bheap"
   "ocb-stubblr" {build}
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "1.0.1"}

--- a/opam
+++ b/opam
@@ -24,6 +24,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
+  "lwt-dllist"
   "ocaml-freestanding" {>= "0.4.1"}
   "logs"
   ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "MirageOS platform support for Solo5"
 version = "%%VERSION_NUM%%"
-requires = "lwt cstruct logs"
+requires = "lwt-dllist bheap lwt cstruct logs"
 archive(byte) = "oS.cma"
 archive(native) = "oS.cmxa"
 plugin(byte) = "oS.cma"


### PR DESCRIPTION
The goal of this PR is to remove usage of depreciated modules :
- `Lwt_sequence` is depreciated and is replaced with `Lwt_dllist`. This is actually the same library, packaged separately.
- `Lwt_pqueue` is depreciated and is replaced with `Binary_heap` (from bheap, as suggested [by the documentation](https://ocsigen.org/lwt/4.1.0/api/Lwt_pqueue). The bheap library allows to extract maximums, so the `compare` function was changed accordingly.