### PR TITLE
Update to new Solo5 "manifest"-style APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: c
-sudo: required
-dist: trusty
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+dist: xenial
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
     global:
         - TESTS=false
     matrix:
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen"
+        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-genode"
         - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt"
-        - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-virtio"
-        - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-muen"
         - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt"
-        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-virtio"
-        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-muen"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt"
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-virtio"
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-muen"
         - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-hvt"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-virtio"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-muen"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
     global:
-        - TESTS=false
+        - TESTS=false PACKAGE=mirage-solo5
     matrix:
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -36,8 +36,8 @@ mirage_solo5_yield_2(value v_deadline)
     bool rc = solo5_yield(deadline, &ready_set);
 
     v_result = caml_alloc_tuple(2);
-    Field(v_result, 0) = Val_bool(rc);
-    Field(v_result, 1) = caml_copy_int64(ready_set);
+    Store_field(v_result, 0, Val_bool(rc));
+    Store_field(v_result, 1, caml_copy_int64(ready_set));
     CAMLreturn(v_result);
 }
 

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Martin Lucina <martin.lucina@docker.com>
+ * Copyright (c) 2019 Martin Lucina <martin@lucina.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -26,14 +26,19 @@ static char *unused_argv[] = { "mirage", NULL };
 static const char *solo5_cmdline = "";
 
 CAMLprim value
-mirage_solo5_yield(value v_deadline)
+mirage_solo5_yield_2(value v_deadline)
 {
     CAMLparam1(v_deadline);
+    CAMLlocal1(v_result);
 
     solo5_time_t deadline = (Int64_val(v_deadline));
-    bool rc = solo5_yield(deadline);
+    solo5_handle_set_t ready_set;
+    bool rc = solo5_yield(deadline, &ready_set);
 
-    CAMLreturn(Val_bool(rc));
+    v_result = caml_alloc_tuple(2);
+    Field(v_result, 0) = Val_bool(rc);
+    Field(v_result, 1) = caml_copy_int64(ready_set);
+    CAMLreturn(v_result);
 }
 
 CAMLprim value

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -29,16 +29,12 @@ CAMLprim value
 mirage_solo5_yield_2(value v_deadline)
 {
     CAMLparam1(v_deadline);
-    CAMLlocal1(v_result);
 
     solo5_time_t deadline = (Int64_val(v_deadline));
     solo5_handle_set_t ready_set;
-    bool rc = solo5_yield(deadline, &ready_set);
+    solo5_yield(deadline, &ready_set);
 
-    v_result = caml_alloc_tuple(2);
-    Store_field(v_result, 0, Val_bool(rc));
-    Store_field(v_result, 1, caml_copy_int64(ready_set));
-    CAMLreturn(v_result);
+    CAMLreturn(caml_copy_int64(ready_set));
 }
 
 CAMLprim value

--- a/lib/bindings/solo5_block_stubs.c
+++ b/lib/bindings/solo5_block_stubs.c
@@ -1,5 +1,6 @@
 /* Copyright (c) 2015, IBM
  * Author(s): Dan Williams <djwillia@us.ibm.com>
+ * Copyright 2019 Martin Lucina <martin@lucina.net>
  *
  * Permission to use, copy, modify, and/or distribute this software
  * for any purpose with or without fee is hereby granted, provided
@@ -27,46 +28,63 @@
 #include <caml/bigarray.h>
 
 CAMLprim value
-mirage_solo5_block_info(value v_unit)
+mirage_solo5_block_acquire(value v_name)
 {
-    CAMLparam1(v_unit);
-    CAMLlocal1(v_result);
+    CAMLparam1(v_name);
+    CAMLlocal2(v_info, v_result);
+    solo5_result_t result;
+    solo5_handle_t handle;
     struct solo5_block_info bi;
 
-    solo5_block_info(&bi);
-    v_result = caml_alloc(2, 0);
-    Store_field(v_result, 0, caml_copy_int64(bi.capacity));
-    Store_field(v_result, 1, caml_copy_int64(bi.block_size));
+    result = solo5_block_acquire(String_val(v_name), &handle, &bi);
+    v_info = caml_alloc(2, 0);
+    if (result != SOLO5_R_OK) {
+        /*
+         * On error (*bi) is not valid, so fake an empty structure to return.
+         */
+        Store_field(v_info, 0, caml_copy_int64(0));
+        Store_field(v_info, 1, caml_copy_int64(0));
+    }
+    else {
+        Store_field(v_info, 0, caml_copy_int64(bi.capacity));
+        Store_field(v_info, 1, caml_copy_int64(bi.block_size));
+    }
 
+    v_result = caml_alloc_tuple(3);
+    Field(v_result, 0) = Val_int(result);
+    Field(v_result, 1) = caml_copy_int64(handle);
+    Field(v_result, 2) = v_info;
     CAMLreturn(v_result);
 }
 
 CAMLprim value
-mirage_solo5_block_read_2(value v_offset, value v_buf, value v_buf_offset,
-        value v_size)
+mirage_solo5_block_read_3(value v_handle, value v_offset, value v_buf,
+        value v_buf_offset, value v_size)
 {
-    CAMLparam4(v_offset, v_buf, v_buf_offset, v_size);
+    CAMLparam5(v_handle, v_offset, v_buf, v_buf_offset, v_size);
+    solo5_handle_t handle = Int64_val(v_handle);
     solo5_off_t offset = Int64_val(v_offset);
     long buf_offset = Long_val(v_buf_offset);
     uint8_t *buf = (uint8_t *)Caml_ba_data_val(v_buf) + buf_offset;
     size_t size = Long_val(v_size);
     solo5_result_t result;
 
-    result = solo5_block_read(offset, buf, size);
+    result = solo5_block_read(handle, offset, buf, size);
     CAMLreturn(Val_int(result));
 }
 
 CAMLprim value
-mirage_solo5_block_write_2(value v_offset, value v_buf, value v_buf_offset,
-        value v_size)
+mirage_solo5_block_write_3(value v_handle, value v_offset, value v_buf,
+        value v_buf_offset, value v_size)
 {
-    CAMLparam4(v_offset, v_buf, v_buf_offset, v_size);
+    CAMLparam5(v_handle, v_offset, v_buf, v_buf_offset, v_size);
+    solo5_handle_t handle = Int64_val(v_handle);
     solo5_off_t offset = Int64_val(v_offset);
     long buf_offset = Long_val(v_buf_offset);
     const uint8_t *buf = (uint8_t *)Caml_ba_data_val(v_buf) + buf_offset;
     size_t size = Long_val(v_size);
     solo5_result_t result;
 
-    result = solo5_block_write(offset, buf, size);
+    result = solo5_block_write(handle, offset, buf, size);
     CAMLreturn(Val_int(result));
 }

--- a/lib/bindings/solo5_block_stubs.c
+++ b/lib/bindings/solo5_block_stubs.c
@@ -51,9 +51,9 @@ mirage_solo5_block_acquire(value v_name)
     }
 
     v_result = caml_alloc_tuple(3);
-    Field(v_result, 0) = Val_int(result);
-    Field(v_result, 1) = caml_copy_int64(handle);
-    Field(v_result, 2) = v_info;
+    Store_field(v_result, 0, Val_int(result));
+    Store_field(v_result, 1, caml_copy_int64(handle));
+    Store_field(v_result, 2, v_info);
     CAMLreturn(v_result);
 }
 

--- a/lib/bindings/solo5_net_stubs.c
+++ b/lib/bindings/solo5_net_stubs.c
@@ -60,9 +60,9 @@ mirage_solo5_net_acquire(value v_name)
     }
 
     v_result = caml_alloc_tuple(3);
-    Field(v_result, 0) = Val_int(result);
-    Field(v_result, 1) = caml_copy_int64(handle);
-    Field(v_result, 2) = v_info;
+    Store_field(v_result, 0, Val_int(result));
+    Store_field(v_result, 1, caml_copy_int64(handle));
+    Store_field(v_result, 2, v_info);
     CAMLreturn(v_result);
 }
 
@@ -81,8 +81,8 @@ mirage_solo5_net_read_3(value v_handle, value v_buf, value v_buf_offset,
     
     result = solo5_net_read(handle, buf, size, &read_size);
     v_result = caml_alloc_tuple(2);
-    Field(v_result, 0) = Val_int(result);
-    Field(v_result, 1) = Val_long(read_size);
+    Store_field(v_result, 0, Val_int(result));
+    Store_field(v_result, 1, Val_long(read_size));
     CAMLreturn(v_result);
 }
 

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -44,13 +44,20 @@ let rec call_hooks hooks  =
             return ()) in
         call_hooks hooks
 
-(* Solo5 currently has an all-or-nothing interface to block and wait for I/O
- * events, so we use a single condition variable to block threads which are
- * waiting for work and wake them all up if I/O is possible.  This will need to
- * be extended once solo5_yield() gains support for selecting events of
- * interest. *)
-let work = Lwt_condition.create ()
-let wait_for_work () = Lwt_condition.wait work
+(* A Map from Int64 (solo5_handle_t) to an Lwt_condition. *)
+module HandleMap = Map.Make(Int64)
+let work = ref HandleMap.empty
+
+(* Wait for work on handle [h]. The Lwt_condition and HandleMap binding are
+ * created lazily the first time [h] is waited on. *)
+let wait_for_work_on_handle h =
+  match HandleMap.find h !work with
+    | exception Not_found ->
+      let cond = Lwt_condition.create () in
+      work := HandleMap.add h cond !work;
+      Lwt_condition.wait cond
+    | cond ->
+      Lwt_condition.wait cond
 
 let err exn =
   Logs.err (fun m -> m "main: %s\n%s" (Printexc.to_string exn) (Printexc.get_backtrace ())) ;
@@ -71,12 +78,15 @@ let run t =
           |None -> Time.Monotonic.(time () + of_nanoseconds 86_400_000_000_000L) (* one day = 24 * 60 * 60 s *)
           |Some tm -> tm
         in
-        let (io_ready, _ready_set) = solo5_yield timeout in
+        let (io_ready, ready_set) = solo5_yield timeout in
         if io_ready then begin
           (* Call enter hooks. *)
           Lwt_dllist.iter_l (fun f -> f ()) enter_iter_hooks;
           (* Some I/O is possible, wake up threads and continue. *)
-          Lwt_condition.broadcast work ();
+          let is_in_set set x =
+            not Int64.(equal zero (logand set (shift_left 1L (to_int x)))) in
+          HandleMap.iter (fun k v ->
+            if is_in_set ready_set k then Lwt_condition.broadcast v ()) !work;
           (* Call leave hooks. *)
           Lwt_dllist.iter_l (fun f -> f ()) exit_iter_hooks;
           aux ()

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -23,7 +23,8 @@
 
 open Lwt
 
-external solo5_yield : [`Time] Time.Monotonic.t -> bool = "mirage_solo5_yield"
+external solo5_yield : [`Time] Time.Monotonic.t -> bool * int64 =
+    "mirage_solo5_yield_2"
 
 let exit_hooks = Lwt_dllist.create ()
 let enter_hooks = Lwt_dllist.create ()
@@ -70,7 +71,8 @@ let run t =
           |None -> Time.Monotonic.(time () + of_nanoseconds 86_400_000_000_000L) (* one day = 24 * 60 * 60 s *)
           |Some tm -> tm
         in
-        if solo5_yield timeout then begin
+        let (io_ready, _ready_set) = solo5_yield timeout in
+        if io_ready then begin
           (* Call enter hooks. *)
           Lwt_dllist.iter_l (fun f -> f ()) enter_iter_hooks;
           (* Some I/O is possible, wake up threads and continue. *)

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -14,7 +14,7 @@ val await_shutdown_request :
 end
 
 module Main : sig
-val wait_for_work : unit -> unit Lwt.t
+val wait_for_work_on_handle : int64 -> unit Lwt.t
 val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
 val at_enter_iter : (unit -> unit) -> unit

--- a/opam
+++ b/opam
@@ -29,16 +29,13 @@ depends: [
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
   "logs"
-  ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
+  ("solo5-bindings-hvt" {>= "0.6.0"} | "solo5-bindings-spt" {>= "0.6.0"} | "solo5-bindings-virtio" {>= "0.6.0"} | "solo5-bindings-muen" {>= "0.6.0"} | "solo5-bindings-genode" {>= "0.6.0"})
 ]
 conflicts: [
   "io-page" {< "2.0.0"}
   "solo5-kernel-ukvm"
   "solo5-kernel-virtio"
   "solo5-kernel-muen"
-]
-post-messages: [
-  "As of MirageOS 3.2.0 / Solo5 0.4.0, the 'ukvm' target has been renamed to 'hvt'. Please refer to https://github.com/mirage/mirage/blob/master/CHANGES.md for further details on this change."
 ]
 synopsis: "Solo5 core platform libraries for MirageOS"
 description: """

--- a/opam
+++ b/opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
   "logs"
-  ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
+  ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
 ]
 conflicts: [
   "io-page" {< "2.0.0"}


### PR DESCRIPTION
Update to Solo5 0.6.0 APIs, support multiple devices. This breaks downstream APIs.

Part of mirage/mirage#992.