### PR TITLE
Use Mirage_runtime.run_{enter,leave}_iter_hooks instead our own hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script: bash -ex .travis-opam.sh
 env:
     global:
         - TESTS=false PACKAGE=mirage-solo5
-        - PINS="mirage-runtime:https://github.com/samoht/mirage.git#runtime-hooks"
     matrix:
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script: bash -ex .travis-opam.sh
 env:
     global:
         - TESTS=false PACKAGE=mirage-solo5
+        - PINS="mirage-runtime:https://github.com/samoht/mirage.git#runtime-hooks"
     matrix:
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"

--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true: bin_annot, safe_string, principal, custom
 true: warn(A-44)
 
 <myocamlbuild.ml>: package(ocb-stubblr)
-<lib/*>: package(bheap lwt-dllist lwt cstruct logs metrics)
+<lib/*>: package(mirage-runtime bheap lwt-dllist lwt cstruct logs metrics)
 <lib/*.cm{x,o}> and not <lib/oS.cmx>: for-pack(OS)
 <lib/bindings/*.c>: pkg-config(ocaml-freestanding)
 <lib/bindings/*.c> : ccopt(-O2 -std=c99 -Wall -Werror)

--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@ true: bin_annot, safe_string, principal, custom
 true: warn(A-44)
 
 <myocamlbuild.ml>: package(ocb-stubblr)
-<lib/*>: package(mirage-runtime bheap lwt-dllist lwt cstruct logs metrics)
+<lib/*>: package(mirage-runtime bheap lwt-dllist lwt cstruct metrics)
 <lib/*.cm{x,o}> and not <lib/oS.cmx>: for-pack(OS)
 <lib/bindings/*.c>: pkg-config(ocaml-freestanding)
 <lib/bindings/*.c> : ccopt(-O2 -std=c99 -Wall -Werror)

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -56,17 +56,13 @@ let wait_for_work_on_handle h =
     | cond ->
       Lwt_condition.wait cond
 
-let err exn =
-  Logs.err (fun m -> m "main: %s\n%s" (Printexc.to_string exn) (Printexc.get_backtrace ())) ;
-  exit 1
-
 (* Execute one iteration and register a callback function *)
 let run t =
   let t = call_hooks enter_hooks <&> t in
   let rec aux () =
     Lwt.wakeup_paused ();
     Time.restart_threads Time.Monotonic.time;
-    match (try Lwt.poll t with exn -> err exn) with
+    match Lwt.poll t with
     | Some () ->
         ()
     | None ->

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -91,6 +91,12 @@ let run t =
   in
   aux ()
 
+let () =
+  at_exit (fun () ->
+    Lwt.abandon_wakeups () ;
+    run (Mirage_runtime.run_exit_hooks ()))
+
 let at_enter f = ignore (Lwt_dllist.add_l f enter_hooks)
 let at_enter_iter f = Mirage_runtime.at_enter_iter f
 let at_exit_iter f = Mirage_runtime.at_leave_iter f
+let at_exit f = Mirage_runtime.at_exit f

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -16,14 +16,6 @@ end
 module Main : sig
 val wait_for_work_on_handle : int64 -> unit Lwt.t
 val run : unit Lwt.t -> unit
-val at_enter : (unit -> unit Lwt.t) -> unit
-[@deprecate "Use Mirage_runtime.at_enter instead"]
-val at_enter_iter : (unit -> unit) -> unit
-[@deprecate "Use Mirage_runtime.at_enter_iter instead"]
-val at_exit_iter  : (unit -> unit) -> unit
-[@deprecate "Use Mirage_runtime.at_exit_iter instead"]
-val at_exit : (unit -> unit Lwt.t) -> unit
-[@deprecate "Use Mirage_runtime.at_exit instead"]
 end
 
 module MM : sig

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -17,9 +17,13 @@ module Main : sig
 val wait_for_work_on_handle : int64 -> unit Lwt.t
 val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
+[@deprecate "Use Mirage_runtime.at_enter instead"]
 val at_enter_iter : (unit -> unit) -> unit
+[@deprecate "Use Mirage_runtime.at_enter_iter instead"]
 val at_exit_iter  : (unit -> unit) -> unit
+[@deprecate "Use Mirage_runtime.at_exit_iter instead"]
 val at_exit : (unit -> unit Lwt.t) -> unit
+[@deprecate "Use Mirage_runtime.at_exit instead"]
 end
 
 module MM : sig

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -19,6 +19,7 @@ val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
 val at_enter_iter : (unit -> unit) -> unit
 val at_exit_iter  : (unit -> unit) -> unit
+val at_exit : (unit -> unit Lwt.t) -> unit
 end
 
 module MM : sig

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -24,8 +24,6 @@ end
 
 module Time : sig
 
-type +'a io = 'a Lwt.t
-
 (** Timeout operations. *)
 
 module Monotonic : sig

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -25,8 +25,6 @@
 
 open Lwt
 
-type +'a io = 'a Lwt.t
-
 module Monotonic = struct
   type time_kind = [`Time | `Interval]
   type 'a t = int64 constraint 'a = [< time_kind]

--- a/opam
+++ b/opam
@@ -28,7 +28,7 @@ depends: [
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
   "logs"
-  "mirage-runtime"
+  "mirage-runtime" {>= "3.7.0"}
   ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
 ]
 conflicts: [

--- a/opam
+++ b/opam
@@ -28,6 +28,7 @@ depends: [
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
   "logs"
+  "mirage-runtime"
   ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
 ]
 conflicts: [

--- a/opam
+++ b/opam
@@ -27,7 +27,6 @@ depends: [
   "lwt-dllist"
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
-  "logs"
   "mirage-runtime" {>= "3.7.0"}
   ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
 ]

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "MirageOS platform support for Solo5"
 version = "%%VERSION_NUM%%"
-requires = "lwt-dllist bheap lwt cstruct logs metrics"
+requires = "lwt-dllist bheap lwt cstruct metrics"
 archive(byte) = "oS.cma"
 archive(native) = "oS.cmxa"
 plugin(byte) = "oS.cma"

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "MirageOS platform support for Solo5"
 version = "%%VERSION_NUM%%"
-requires = "lwt-dllist bheap lwt cstruct metrics"
+requires = "mirage-runtime lwt-dllist bheap lwt cstruct metrics"
 archive(byte) = "oS.cma"
 archive(native) = "oS.cmxa"
 plugin(byte) = "oS.cma"


### PR DESCRIPTION
This little PR is a draft to use `Mirage_runtime.run_{enter,leave}_iter_hooks` instead internals hooks. It follows mirage/mirage#1010 and currently works with [dinosaure/mirage-os-shinimy](https://github.com/dinosaure/mirage-os-shinimy). Let's talk about general purpose on mirage/mirage#1010 and details about Solo5 here.