### PR TITLE
Add support for OCaml 4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     global:
         - TESTS=false PACKAGE=mirage-solo5
     matrix:
-        - OCAML_VERSION=4.10.0+rc2 OCAML_BETA="enable" EXTRA_DEPS="solo5-bindings-hvt"
+        - OCAML_VERSION=4.10 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     global:
         - TESTS=false PACKAGE=mirage-solo5
     matrix:
+        - OCAML_VERSION=4.10.0+rc2 OCAML_BETA="enable" EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio"

--- a/lib/bindings/cstruct_stubs.c
+++ b/lib/bindings/cstruct_stubs.c
@@ -27,7 +27,7 @@
 CAMLprim value
 caml_blit_bigstring_to_string(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
 {
-  memcpy(String_val(val_buf2) + Long_val(val_ofs2),
+  memcpy(Bytes_val(val_buf2) + Long_val(val_ofs2),
          (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
          Long_val(val_len));
   return Val_unit;

--- a/lib/bindings/solo5_net_stubs.c
+++ b/lib/bindings/solo5_net_stubs.c
@@ -49,11 +49,7 @@ mirage_solo5_net_acquire(value v_name)
     }
     else {
         v_mac_address = caml_alloc_string(SOLO5_NET_ALEN);
-#if defined(Bytes_val)
         memcpy(Bytes_val(v_mac_address), ni.mac_address, SOLO5_NET_ALEN);
-#else
-        memcpy(String_val(v_mac_address), ni.mac_address, SOLO5_NET_ALEN);
-#endif
         Store_field(v_info, 0, v_mac_address);
         Store_field(v_info, 1, Val_long(ni.mtu));
     }


### PR DESCRIPTION
In OCaml 4.10 the type of `String_val` changes from `char*` to `const char*`. `Bytes_val` should be used instead and it is compatible with older versions since mirage-solo5 requires at least OCaml 4.06 and `Bytes_val` was added in OCaml 4.06.