### PR TITLE
aarch32 support

### DIFF
--- a/lib/bindings/barrier_stubs.c
+++ b/lib/bindings/barrier_stubs.c
@@ -25,7 +25,7 @@
 #define mb()     __asm__ __volatile__("mfence" ::: "memory")
 #define rmb()    __asm__ __volatile__("lfence" ::: "memory")
 #define wmb()    __asm__ __volatile__("sfence" ::: "memory")
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__arm__)
 #define dsb(opt) __asm__ __volatile__("dsb " #opt ::: "memory")
 #define mb()     dsb(sy)
 #define rmb()    dsb(ld)

--- a/lib/bindings/cstruct_stubs.c
+++ b/lib/bindings/cstruct_stubs.c
@@ -72,7 +72,11 @@ caml_fill_bigstring(value val_buf, value val_ofs, value val_len, value val_byte)
 CAMLprim value
 caml_check_alignment_bigstring(value val_buf, value val_ofs, value val_alignment)
 {
+#if defined(__BITS_32__)
+  uint32_t address = (uint32_t) (Caml_ba_data_val(val_buf) + Long_val(val_ofs));
+#else
   uint64_t address = (uint64_t) (Caml_ba_data_val(val_buf) + Long_val(val_ofs));
+#endif
   int alignment = Int_val(val_alignment);
   return Val_bool(address % alignment == 0);
 }


### PR DESCRIPTION
This is small modification to support the aarch32 architecture by Solo5.

Related pull requests can be found at https://github.com/Solo5/solo5/pull/470 and https://github.com/mirage/ocaml-freestanding/pull/78.