### PR TITLE
Get rid of calls to opam when using opam

### DIFF
--- a/lib/cflags.sh
+++ b/lib/cflags.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-export PKG_CONFIG_PATH="$(opam config var lib)/pkgconfig"
-flags="$(pkg-config --static ocaml-freestanding --cflags)"
-echo "($flags)"

--- a/lib/dune
+++ b/lib/dune
@@ -15,7 +15,13 @@
 
 (include_subdirs unqualified)
 
-(rule (with-stdout-to cflags.sexp (run ./cflags.sh)))
+(rule
+  (with-stdout-to cflags.sexp
+    (progn
+      (echo "(")
+      (setenv PKG_CONFIG_PATH "%{lib:ocaml-freestanding:}/../pkgconfig"
+        (run pkg-config --static ocaml-freestanding --cflags))
+      (echo ")"))))
 
 (install
  (section lib)


### PR DESCRIPTION
Currently using opam 2.1~alpha (this is probably a bug but it might break in the future), mirage-solo5 fails to install because it uses `opam config var` while already being inside opam.

This PR gets rid of the issue by using dune variables. However I didn't found a way to directly get the `PREFIX` (e.g. `~/.opam/<switch>/`) with dune other than relying on the "hack" `%{lib:pkgconfig:}/../pkgconfig`, so I'm tagging this PR as a draft for now to start a discussion. cc @jeremiedimino @rgrinberg is there a cleaner way to get the opam prefix with dune?