### PR TITLE
Adapt to bheap.2.0.0 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio"
         - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen"
-        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-genode"
         - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt"

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -18,7 +18,7 @@ build: [
 ]
 depends: [
   "dune" {>= "2.0.0"}
-  "bheap"
+  "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.06.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}


### PR DESCRIPTION
Some API changes occured in `bheap` for the last release (https://github.com/ocaml/opam-repository/pull/17127).
It is recommended to use the latest version as it fixes the memory footprint and the API is more adapted to the use-case here. Namely it is no operating on minimums instead of maximums, (avoiding `invert_comparison`) and allow to create queues with initial size `0`.
It now requires a `dummy` value on creation, this is used internally to make sure no pointers are kept to unused values, that would prevent the GC from collecting them.
/cc @backtracking 