### PR TITLE
remove Time.Monotonic submodule to unify mirage-solo5 with mirage-unix

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name oS)
  (public_name mirage-solo5)
  (private_modules lifecycle main mM time solo5)
- (libraries mirage-runtime bheap lwt cstruct metrics)
+ (libraries mirage-runtime bheap lwt cstruct metrics duration)
  (foreign_archives mirage-solo5_bindings))
 
 (foreign_library

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -21,8 +21,7 @@
  * 02111-1307, USA.
  *)
 
-external solo5_yield : [`Time] Time.Monotonic.t -> int64 =
-    "mirage_solo5_yield_2"
+external solo5_yield : Time.t -> int64 = "mirage_solo5_yield_2"
 
 (* A Map from Int64 (solo5_handle_t) to an Lwt_condition. *)
 module HandleMap = Map.Make(Int64)
@@ -43,7 +42,7 @@ let wait_for_work_on_handle h =
 let run t =
   let rec aux () =
     Lwt.wakeup_paused ();
-    Time.restart_threads Time.Monotonic.time;
+    Time.restart_threads Time.time;
     match Lwt.poll t with
     | Some () ->
         ()
@@ -52,7 +51,7 @@ let run t =
         Mirage_runtime.run_enter_iter_hooks () ;
         let timeout =
           match Time.select_next () with
-          |None -> Time.Monotonic.(time () + of_nanoseconds 86_400_000_000_000L) (* one day = 24 * 60 * 60 s *)
+          |None -> Time.(time () + Duration.of_day 1)
           |Some tm -> tm
         in
         let ready_set = solo5_yield timeout in

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -24,49 +24,8 @@ end
 
 module Time : sig
 
-(** Timeout operations. *)
-
-module Monotonic : sig
-  (** Monotonic time is time since boot (dom0 or domU, depending on platform).
-   * Unlike Clock.time, it does not go backwards when the system clock is
-   * adjusted. *)
-
-  type time_kind = [`Time | `Interval]
-  type 'a t constraint 'a = [< time_kind]
-
-  val time : unit -> [`Time] t
-  (** Read the current monotonic time. *)
-
-  val ( + ) : 'a t -> [`Interval] t -> 'a t
-  val ( - ) : 'a t -> [`Interval] t -> 'a t
-  val interval : [`Time] t -> [`Time] t -> [`Interval] t
-
-  (** Conversions. Note: still seconds since boot. *)
-  val of_nanoseconds : int64 -> _ t
-end
-
-val restart_threads: (unit -> [`Time] Monotonic.t) -> unit
-(** [restart_threads time_fun] restarts threads that are sleeping and
-    whose wakeup time is before [time_fun ()]. *)
-
-val select_next : unit -> [`Time] Monotonic.t option
-(** [select_next ()] is [Some t] where [t] is the earliest time
-    when one sleeping thread will wake up, or [None] if there is no
-    sleeping threads. *)
-
 val sleep_ns : int64 -> unit Lwt.t
 (** [sleep_ns d] Block the current thread for [n] nanoseconds. *)
-
-exception Timeout
-(** Exception raised by timeout operations *)
-
-val with_timeout : int64 -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-(** [with_timeout d f] is a short-hand for:
-
-    {[
-    Lwt.pick [Lwt_unix.timeout d; f ()]
-    ]}
-*)
 end
 
 module Solo5 : sig

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml-freestanding" {>= "0.4.5"}
   "metrics"
   "mirage-runtime" {>= "3.7.0"}
+  "duration"
   ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
 ]
 conflicts: [


### PR DESCRIPTION
the Time.Monotonic module was initially copied over from mirage-xen, and has not been used in any unikernels.

This PR reduces the exposed API of mirage-solo5, and streamlines the `Time` module with mirage-unix. Also, instead of hardcoding the number of seconds of a day, the `duration` library (which is dependency-free) is used.

Over time, MirageOS moved to use the `Time` module (`Mirage_time.S`) instead of backend-specific (unix, xen, soo5) interfaces and implementations. This is an API breaking change, but I could not find any unikernel which uses the removed Time.Monotonic interface. Once the dust in mirage-xen settles, I'll prepare PRs to streamline that implementation with mirage-solo5 one.