### PR TITLE
dune: use -Werror only in development mode, add :standard

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,10 @@
  (names alloc_pages_stubs clock_stubs mm_stubs atomic_stubs cstruct_stubs
         solo5_block_stubs barrier_stubs main solo5_console_stubs checksum_stubs
         solo5_net_stubs)
- (flags (:include cflags.sexp) -O2 -std=c99 -Wall -Werror))
+ (flags (:standard) (:include cflags.sexp) -O2 -std=c99 -Wall))
+
+(env
+  (dev (c_flags (-Werror))))
 
 (include_subdirs unqualified)
 


### PR DESCRIPTION
Using `-Werror` in released packages is brittle: C compilers tend to add new warnings with new releases (which we can't predict that we don't violate).

In development mode (this means: a local run of `dune build`), we keep the `-Werror`, but in production (i.e. opam-installed) we avoid adding `-Werror`. This makes released mirage-solo5 packages more robust.

In addition, we add `:standard` to the CFLAGS (which is `-O2 -fno-strict-aliasing -fwrapv -fPIC` on my platform & dune -- run `dune printenv` to see how it is on your platform). This is in general a good idea AFAICT (see discussion in https://github.com/mirage/mirage-crypto/pull/47).