### PR TITLE
Synchronise with mirage-xen

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 2.0)
+(lang dune 2.6)
 (name mirage-solo5)

--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -1,0 +1,17 @@
+PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+
+CC ?= cc
+FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)
+CFLAGS := $(FREESTANDING_CFLAGS) \
+    -O2 -std=c99 -Wall -Werror
+
+.PHONY: all clean
+all: libmirage-solo5_bindings.a
+
+OBJS=alloc_pages_stubs.o clock_stubs.o mm_stubs.o atomic_stubs.o cstruct_stubs.o solo5_block_stubs.o barrier_stubs.o main.o solo5_console_stubs.o checksum_stubs.o solo5_net_stubs.o
+
+libmirage-solo5_bindings.a: $(OBJS)
+	$(AR) r $@ $^
+
+clean:
+	$(RM) $(OBJS) libmirage-xen_bindings.a

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -24,6 +24,8 @@
 
 static char *unused_argv[] = { "mirage", NULL };
 static const char *solo5_cmdline = "";
+static size_t solo5_heap_size;
+static uintptr_t sp_at_start;
 
 CAMLprim value
 mirage_solo5_yield_2(value v_deadline)
@@ -45,12 +47,52 @@ mirage_solo5_get_cmdline(value unit)
     CAMLreturn(caml_copy_string(solo5_cmdline));
 }
 
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_memory_get_heap_words(value v_unit)
+{
+    return Val_long(solo5_heap_size / sizeof(value));
+}
+
+extern size_t malloc_footprint(void);
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_memory_get_live_words(value v_unit)
+{
+    return Val_long(malloc_footprint() / sizeof(value));
+}
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ *
+ * The implementation currently uses a hard-coded value for the stack guard
+ * size; this must be kept in sync with nolibc's sbrk() implementation.
+ * TODO: Consider providing a formal interface for this.
+ */
+CAMLprim value
+mirage_memory_get_stack_words(value v_unit)
+{
+    int dummy;
+
+    return Val_long((sp_at_start - (uintptr_t)&dummy + 0x100000)
+            / sizeof(value));
+}
+
 extern void _nolibc_init(uintptr_t, size_t);
 
 int solo5_app_main(const struct solo5_start_info *si)
 {
-    solo5_cmdline = si->cmdline;
+    int dummy;
+
+    sp_at_start = (uintptr_t)&dummy;
     _nolibc_init(si->heap_start, si->heap_size);
+    solo5_heap_size = si->heap_size;
+    solo5_cmdline = si->cmdline;
     caml_startup(unused_argv);
 
     return 0;

--- a/lib/cflags.sh
+++ b/lib/cflags.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-export PKG_CONFIG_PATH="$(opam config var lib)/pkgconfig"
-flags="$(pkg-config --static ocaml-freestanding --cflags)"
-echo "($flags)"

--- a/lib/dune
+++ b/lib/dune
@@ -2,21 +2,20 @@
  (name oS)
  (public_name mirage-solo5)
  (private_modules lifecycle main mM time solo5)
- (libraries mirage-runtime bheap lwt cstruct metrics duration)
- (foreign_archives mirage-solo5_bindings))
+ (libraries mirage-runtime bheap lwt cstruct metrics duration))
 
-(foreign_library
- (archive_name mirage-solo5_bindings)
- (language c)
- (names alloc_pages_stubs clock_stubs mm_stubs atomic_stubs cstruct_stubs
-        solo5_block_stubs barrier_stubs main solo5_console_stubs checksum_stubs
-        solo5_net_stubs)
- (flags (:include cflags.sexp) -O2 -std=c99 -Wall -Werror))
+(rule
+ (deps (source_tree bindings))
+ (target libmirage-solo5_bindings.a)
+ (action
+  (no-infer
+   (progn
+    (chdir bindings (run %{make}))
+    (copy bindings/libmirage-solo5_bindings.a libmirage-solo5_bindings.a)))))
 
 (include_subdirs unqualified)
 
-(rule (with-stdout-to cflags.sexp (run ./cflags.sh)))
-
 (install
  (section lib)
- (files (bindings/mirage-solo5.pc as ../pkgconfig/mirage-solo5.pc)))
+ (files (bindings/mirage-solo5.pc as ../pkgconfig/mirage-solo5.pc)
+   libmirage-solo5_bindings.a))

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -1,0 +1,37 @@
+(**
+ * Copyright (c) 2020 Martin Lucina <martin@lucina.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+external get_heap_words: unit -> int =
+    "mirage_memory_get_heap_words" [@@noalloc]
+
+external get_live_words: unit -> int =
+    "mirage_memory_get_live_words" [@@noalloc]
+
+external get_stack_words: unit -> int =
+    "mirage_memory_get_stack_words" [@@noalloc]
+
+type stat = {
+  heap_words: int;
+  live_words: int;
+  stack_words: int;
+  free_words: int;
+}
+
+let quick_stat () =
+  let h = get_heap_words () in
+  let l = get_live_words () in
+  let s = get_stack_words () in
+  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }

--- a/lib/oS.ml
+++ b/lib/oS.ml
@@ -1,5 +1,6 @@
 module Lifecycle = Lifecycle
 module Main = Main
+module Memory = Memory
 module MM = MM
 module Time = Time
 module Solo5 = Solo5

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -18,8 +18,29 @@ val wait_for_work_on_handle : int64 -> unit Lwt.t
 val run : unit Lwt.t -> unit
 end
 
+module Memory : sig
+
+  (** Memory management operations. *)
+
+  (** Memory allocation statistics. Units are the system word size, as used by
+      the OCaml stdlib Gc module. *)
+  type stat = {
+    heap_words : int;  (** total number of words allocatable on the heap. *)
+    live_words : int;  (** number of live (i.e. allocated) words on the heap. *)
+    stack_words : int; (** number of words in use by the program stack.
+                           This includes any space reserved by a stack guard. *)
+    free_words : int;  (** number of free (i.e. allocatable) words on the heap. *)
+  }
+
+  val quick_stat: unit -> stat
+  (** [quick_stat ()]  returns memory allocation statistics. This call is
+      computationally cheap, but the returned values may not be completely
+      accurate. *)
+end
+
 module MM : sig
   val malloc_metrics : tags:'a Metrics.Tags.t -> ('a, unit -> Metrics.Data.t) Metrics.src
+  [@@ocaml.deprecated "This function will be deprecated. Use {!Memory.quick_stat} instead."]
 end
 
 module Time : sig

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -41,10 +41,10 @@ type sleep = {
 
 module SleepQueue =
   Binary_heap.Make (struct
-                     type t = sleep
-                     let compare { time = t1; _ } { time = t2; _ } =
-                       compare t1 t2
-                   end)
+                      type t = sleep
+                      let compare { time = t1; _ } { time = t2; _ } =
+                        compare t1 t2
+                    end)
 
 (* Threads waiting for a timeout to expire: *)
 let sleep_queue =
@@ -103,7 +103,7 @@ let rec restart_threads now =
       SleepQueue.remove sleep_queue;
       m ();
       restart_threads now
-  | { time = time; thread = thread; _ } when in_the_past now time ->
+  | { time; thread; _ } when in_the_past now time ->
       SleepQueue.remove sleep_queue;
       m ();
       Lwt.wakeup thread ();
@@ -114,11 +114,6 @@ let rec restart_threads now =
    | Event loop                                                      |
    +-----------------------------------------------------------------+ *)
 
-let min_timeout a b = match a, b with
-  | None, b -> b
-  | a, None -> a
-  | Some a, Some b -> Some(min a b)
-
 let rec get_next_timeout () =
   match SleepQueue.minimum sleep_queue with
   | exception Binary_heap.Empty -> None
@@ -126,7 +121,7 @@ let rec get_next_timeout () =
       SleepQueue.remove sleep_queue;
       m ();
       get_next_timeout ()
-  | { time = time; _ } ->
+  | { time; _ } ->
       Some time
 
 let select_next () =

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -17,7 +17,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {>= "2.0.0"}
+  "dune" {>= "2.6.0"}
   "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.06.0"}
   "cstruct" {>= "1.0.1"}


### PR DESCRIPTION
This PR minimizes the difference between mirage-xen and mirage-solo5. To be finished and merged once mirage-xen 6.0.0 is released.
Changes included:
- remove unused Time.min_timeout
- adapt time.ml to mirage-xen's syntax
- use make to build libmirage-solo5_bindings.a instead of dune
- provide OS.Memory, the same interface as mirage/mirage-xen#26 (deprecating the old MM interface)