### PR TITLE
Use conf-pkg-config.2 instead of calling opam

### DIFF
--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -1,7 +1,5 @@
-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
-
 CC ?= cc
-FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)
+FREESTANDING_CFLAGS := $(shell pkg-config --cflags ocaml-freestanding)
 CFLAGS := $(FREESTANDING_CFLAGS) \
     -O2 -std=c99 -Wall -Werror
 

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -13,11 +13,12 @@ tags: [
   "org:mirage"
 ]
 build: [
-  ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs ]
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "dune" {>= "2.6.0"}
+  "conf-pkg-config" {build & >= "2"}
   "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.06.0"}
   "cstruct" {>= "1.0.1"}


### PR DESCRIPTION
conf-pkg-config.2 brings up the correct PKG_CONFIG_PATH variable already so calling opam var is unnecessary