### PR TITLE
Mirage 3/4 compatibility patch

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,4 @@
+(alias
+ (name default)
+ (deps
+  (package mirage-solo5)))

--- a/lib/bindings/dune
+++ b/lib/bindings/dune
@@ -1,0 +1,7 @@
+(rule
+ (deps (source_tree .))
+ (targets libmirage-solo5_bindings.a)
+ (action
+  (no-infer
+   (progn
+    (run %{make})))))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,22 @@
 (library
+ (name oS_stubs)
+ (modules)
+ (foreign_stubs
+  (language c)
+  (names
+   alloc_pages_stubs
+   atomic_stubs
+   barrier_stubs
+   checksum_stubs
+   clock_stubs
+   cstruct_stubs
+   main
+   mm_stubs
+   solo5_block_stubs
+   solo5_console_stubs
+   solo5_net_stubs)))
+
+(library
  (name oS)
  (public_name mirage-solo5)
  (private_modules lifecycle main mM time solo5)
@@ -6,19 +24,28 @@
  (no_dynlink)
  (foreign_archives mirage-solo5_bindings))
 
-(rule
- (deps
-  (source_tree bindings))
- (target libmirage-solo5_bindings.a)
- (action
-  (no-infer
-   (progn
-    (chdir
-     bindings
-     (run %{make}))
-    (copy bindings/libmirage-solo5_bindings.a libmirage-solo5_bindings.a)))))
+(copy_files# ./bindings/*.c)
 
-(include_subdirs unqualified)
+; Mirage 4
+
+(rule
+ (target libmirage-solo5_bindings.true.a)
+ (action
+  (copy liboS_stubs_stubs.a %{target})))
+
+; Mirage 3
+
+(rule
+ (target libmirage-solo5_bindings.false.a)
+ (action
+  (copy bindings/libmirage-solo5_bindings.a %{target})))
+
+(rule
+ (target libmirage-solo5_bindings.a)
+ (deps
+  (:dep libmirage-solo5_bindings.%{lib-available:is_freestanding}.a))
+ (action
+  (copy %{dep} %{target})))
 
 (install
  (section lib)

--- a/lib/dune
+++ b/lib/dune
@@ -4,10 +4,8 @@
  (foreign_stubs
   (language c)
   (names
-   alloc_pages_stubs
    atomic_stubs
    barrier_stubs
-   checksum_stubs
    clock_stubs
    cstruct_stubs
    main

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,8 @@
 (library
  (name oS_stubs)
  (modules)
+ (libraries is_freestanding)
+ (optional)
  (foreign_stubs
   (language c)
   (names

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,9 @@
  (name oS)
  (public_name mirage-solo5)
  (private_modules lifecycle main mM time solo5)
- (libraries mirage-runtime bheap lwt cstruct metrics duration))
+ (libraries mirage-runtime bheap lwt cstruct metrics duration)
+ (no_dynlink)
+ (foreign_archives mirage-solo5_bindings))
 
 (rule
  (deps
@@ -21,5 +23,4 @@
 (install
  (section lib)
  (files
-  (bindings/mirage-solo5.pc as ../pkgconfig/mirage-solo5.pc)
-  libmirage-solo5_bindings.a))
+  (bindings/mirage-solo5.pc as ../pkgconfig/mirage-solo5.pc)))

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -25,11 +25,11 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  ("ocaml-freestanding" {>= "0.4.5"} | "mirage" {>= "4.0.0"})
+  ("ocaml-freestanding" {>= "0.4.5"} | "mirage-runtime" {>= "4.0.0"})
   "metrics"
   "mirage-runtime" {>= "3.7.0"}
   "duration"
-  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"} | "mirage" {>= "4.0.0"})
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"} | "mirage-runtime" {>= "4.0.0"})
 ]
 conflicts: [
   "io-page" {< "2.4.0"}

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -16,17 +16,20 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs ]
 ]
+messages: [
+  "When used with Mirage 4, this package should not be installed through opam." { mirage:version >= "4.0.0" }
+]
 depends: [
   "dune" {>= "2.6.0"}
   "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "ocaml-freestanding" {>= "0.4.5"}
+  ("ocaml-freestanding" {>= "0.4.5"} | "mirage" {>= "4.0.0"})
   "metrics"
   "mirage-runtime" {>= "3.7.0"}
   "duration"
-  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"} | "mirage" {>= "4.0.0"})
 ]
 conflicts: [
   "io-page" {< "2.4.0"}


### PR DESCRIPTION
This PR is not ready yet but it keep in our minds that we need a patch to be compatible with MirageOS 3 and 4. The issue was spotted while the cross-compilation of some unikernels, I need to test this patch with the current state of MirageOS 3 but it seems fine.