### PR TITLE
bindings Makefile: only invoke `opam var prefix` if opam is available

### DIFF
--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -1,4 +1,6 @@
-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+ifneq (, $(shell command -v opam))
+PKG_CONFIG_PATH ?= $(shell opam var prefix)/lib/pkgconfig
+endif
 
 CC ?= cc
 FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "dune" {>= "2.6.0"}
   "bheap" {>= "2.0.0"}
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
   "ocaml-freestanding" {>= "0.4.5"}


### PR DESCRIPTION
Such a change has been trickled through other MirageOS3 cross-compilation
Makefiles as well. Also, use `opam var prefix`, not the deprecated
`opam config var prefix`. This also allows clean NixOS compilation.