### PR TITLE
update with the new ocaml-solo5 interface

### DIFF
--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -56,7 +56,12 @@ mirage_memory_get_heap_words(value v_unit)
     return Val_long(solo5_heap_size / sizeof(value));
 }
 
+/*
+ * defined in ocaml freestanding dlmalloc.i
+*/
 extern size_t malloc_footprint(void);
+extern size_t malloc_memory_usage(void);
+extern int malloc_trim(size_t pad);
 
 /*
  * Caller: OS.Memory, @@noalloc
@@ -64,7 +69,17 @@ extern size_t malloc_footprint(void);
 CAMLprim value
 mirage_memory_get_live_words(value v_unit)
 {
-    return Val_long(malloc_footprint() / sizeof(value));
+    struct mallinfo m = mallinfo();
+    return Val_long(m.uordblks / sizeof(value));
+}
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_memory_get_fast_live_words(value v_unit)
+{
+    return Val_long(malloc_memory_usage() / sizeof(value));
 }
 
 /*
@@ -81,6 +96,15 @@ mirage_memory_get_stack_words(value v_unit)
 
     return Val_long((sp_at_start - (uintptr_t)&dummy + 0x100000)
             / sizeof(value));
+}
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_trim_allocation(value v_unit)
+{
+    return Val_long(malloc_trim(0));
 }
 
 extern void _nolibc_init(uintptr_t, size_t);

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -20,14 +20,13 @@ external get_heap_words : unit -> int = "mirage_memory_get_heap_words"
 external get_live_words : unit -> int = "mirage_memory_get_live_words"
   [@@noalloc]
 
-external get_fast_live_words: unit -> int = "mirage_memory_get_fast_live_words"
+external get_fast_live_words : unit -> int = "mirage_memory_get_fast_live_words"
   [@@noalloc]
 
 external get_stack_words : unit -> int = "mirage_memory_get_stack_words"
   [@@noalloc]
 
-external trim: unit -> unit = "mirage_trim_allocation"
-  [@@noalloc]
+external trim : unit -> unit = "mirage_trim_allocation" [@@noalloc]
 
 type stat = {
   heap_words : int;
@@ -46,4 +45,4 @@ let quick_stat () =
   let h = get_heap_words () in
   let l = get_fast_live_words () in
   let s = get_stack_words () in
-  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }
+  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s }

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -20,7 +20,13 @@ external get_heap_words : unit -> int = "mirage_memory_get_heap_words"
 external get_live_words : unit -> int = "mirage_memory_get_live_words"
   [@@noalloc]
 
+external get_fast_live_words: unit -> int = "mirage_memory_get_fast_live_words"
+  [@@noalloc]
+
 external get_stack_words : unit -> int = "mirage_memory_get_stack_words"
+  [@@noalloc]
+
+external trim: unit -> unit = "mirage_trim_allocation"
   [@@noalloc]
 
 type stat = {
@@ -30,8 +36,14 @@ type stat = {
   free_words : int;
 }
 
-let quick_stat () =
+let stat () =
   let h = get_heap_words () in
   let l = get_live_words () in
   let s = get_stack_words () in
   { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s }
+
+let quick_stat () =
+  let h = get_heap_words () in
+  let l = get_fast_live_words () in
+  let s = get_stack_words () in
+  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }

--- a/lib/solo5_os.mli
+++ b/lib/solo5_os.mli
@@ -31,19 +31,19 @@ module Memory : sig
   (** Memory allocation statistics. Units are the system word size, as used by
       the OCaml stdlib Gc module. *)
 
-  val stat: unit -> stat
-  (** [stat ()]  returns memory allocation statistics. This uses mallinfo
-      and walks over the entire heap. This call is slower than quick_stat. *)
+  val stat : unit -> stat
+  (** [stat ()] returns memory allocation statistics. This uses mallinfo and
+      walks over the entire heap. This call is slower than quick_stat. *)
 
   val quick_stat : unit -> stat
 
-  (** [quick_stat ()] returns memory allocation statistics. This call uses
-      a precomputed value. This call is cheaper than stat, but the returned
-      values may not be completely accurate. *)
+  (** [quick_stat ()] returns memory allocation statistics. This call uses a
+      precomputed value. This call is cheaper than stat, but the returned values
+      may not be completely accurate. *)
 
-  val trim: unit -> unit
-  (** [trim ()]  release free memory from the heap (may update the value
-      returned by quick_state) *)
+  val trim : unit -> unit
+  (** [trim ()] release free memory from the heap (may update the value returned
+      by quick_state) *)
 end
 
 module MM : sig

--- a/lib/solo5_os.mli
+++ b/lib/solo5_os.mli
@@ -31,10 +31,19 @@ module Memory : sig
   (** Memory allocation statistics. Units are the system word size, as used by
       the OCaml stdlib Gc module. *)
 
+  val stat: unit -> stat
+  (** [stat ()]  returns memory allocation statistics. This uses mallinfo
+      and walks over the entire heap. This call is slower than quick_stat. *)
+
   val quick_stat : unit -> stat
-  (** [quick_stat ()] returns memory allocation statistics. This call is
-      computationally cheap, but the returned values may not be completely
-      accurate. *)
+
+  (** [quick_stat ()] returns memory allocation statistics. This call uses
+      a precomputed value. This call is cheaper than stat, but the returned
+      values may not be completely accurate. *)
+
+  val trim: unit -> unit
+  (** [trim ()]  release free memory from the heap (may update the value
+      returned by quick_state) *)
 end
 
 module MM : sig


### PR DESCRIPTION
As discussed previously with @dinosaure, with version v0.8.1 of ocaml-solo5, we can now have stats on the heap allocs & frees. This PR is identical to the PR on mirage-xen as we use solo5 in both cases. As @hannesm pointed out, I'm not sure how to add a constraint on a specific ocaml-solo5 version ?