### PR TITLE
Event loop: yield but don't sleep if there are paused tasks

### DIFF
--- a/lib/main.ml
+++ b/lib/main.ml
@@ -49,9 +49,11 @@ let run t =
         (* Call enter hooks. *)
         Mirage_runtime.run_enter_iter_hooks ();
         let timeout =
-          match Time.select_next () with
-          | None -> Int64.add (Time.time ()) (Duration.of_day 1)
-          | Some tm -> tm
+          if Lwt.paused_count () > 0 then 0L
+          else
+            match Time.select_next () with
+            | None -> Int64.add (Time.time ()) (Duration.of_day 1)
+            | Some tm -> tm
         in
         let ready_set = solo5_yield timeout in
         (if not (Int64.equal 0L ready_set) then


### PR DESCRIPTION
Programs that uses `Lwt.pause ()` are potentially running slower than expected because they are sleeping between each iteration. 
The sleep time is chosen by the `Time.select_next` function, but it should be zero if there are paused continuations as they should be resumed as soon as possible, even if `solo5_yield` still has to be used to check for external events. 