### PR TITLE
Record backtraces by default

### DIFF
--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -21,6 +21,7 @@
 #include <caml/memory.h>
 #include <caml/callback.h>
 #include <caml/alloc.h>
+#include <caml/backtrace.h>
 
 static char *unused_argv[] = { "mirage", NULL };
 static const char *solo5_cmdline = "";
@@ -117,6 +118,7 @@ int solo5_app_main(const struct solo5_start_info *si)
     _nolibc_init(si->heap_start, si->heap_size);
     solo5_heap_size = si->heap_size;
     solo5_cmdline = si->cmdline;
+    caml_record_backtraces(1);
     caml_startup(unused_argv);
 
     return 0;

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "dune" {>= "2.7.0"}
   "bheap" {>= "2.0.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
   "metrics"


### PR DESCRIPTION
This enables backtraces by default. This can be considered an alternative to https://github.com/mirage/mirage/pull/1584. There are performance downsides to code that uses exceptions a lot. However, backtrace recording can still be disabled at runtime (in mirage through the `--backtrace` option).

Defaulting to initially recording backtraces is in my opinion favorable as it for solo5 applications isn't possible to pass `OCAMLRUNPARAM=b` environment variable.

- [ ] Testing this approach works.