### PR TITLE
cstruct is not needed anymore

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name solo5_os)
  (public_name mirage-solo5)
  (private_modules lifecycle main memory time solo5)
- (libraries mirage-runtime bheap lwt cstruct metrics metrics-lwt duration)
+ (libraries mirage-runtime bheap lwt metrics metrics-lwt duration)
  (no_dynlink)
  (foreign_archives mirage-solo5_bindings))
 

--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -20,7 +20,6 @@ depends: [
   "dune" {>= "2.7.0"}
   "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.08.0"}
-  "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
   "metrics"
   "metrics-lwt" {>= "0.2.0"}


### PR DESCRIPTION
Dear mirage developpers,
Current mirage-solo5 has no Cstruct occurrences, so we may lighten the dependency cone?
Best.