### PR TITLE
Use array for device handles

### DIFF
--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -16,8 +16,6 @@
 
 #include "solo5.h"
 
-#include <stdbit.h>
-
 #define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -115,7 +113,7 @@ mirage_trim_allocation(value v_unit)
 CAMLprim value
 mirage_flo64(value v_int64)
 {
-    return Val_int(stdc_first_leading_one_ull(Int64_val(v_int64)));
+    return Val_int(__builtin_clzll(Int64_val(v_int64)));
 }
 
 extern void _nolibc_init(uintptr_t, size_t);

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -16,6 +16,8 @@
 
 #include "solo5.h"
 
+#include <stdbit.h>
+
 #define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -105,6 +107,15 @@ CAMLprim value
 mirage_trim_allocation(value v_unit)
 {
     return Val_long(malloc_trim(0));
+}
+
+/*
+ * Caller: Main, @@noalloc
+ */
+CAMLprim value
+mirage_flo64(value v_int64)
+{
+    return Val_int(stdc_first_leading_one_ull(Int64_val(v_int64)));
 }
 
 extern void _nolibc_init(uintptr_t, size_t);

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -111,7 +111,7 @@ mirage_trim_allocation(value v_unit)
  * Caller: Main, @@noalloc
  */
 CAMLprim value
-mirage_flo64(value v_int64)
+mirage_clzll(value v_int64)
 {
     return Val_int(__builtin_clzll(Int64_val(v_int64)));
 }

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -22,21 +22,17 @@
  *)
 
 external solo5_yield : Time.t -> int64 = "mirage_solo5_yield_2"
+external flo64 : int64 -> int = "mirage_flo64"
+[@@noalloc]
 
-(* A Map from Int64 (solo5_handle_t) to an Lwt_condition. *)
-module HandleMap = Map.Make (Int64)
-
-let work = ref HandleMap.empty
+let work = Array.init 64 (fun _ -> Lwt_condition.create ())
 
 (* Wait for work on handle [h]. The Lwt_condition and HandleMap binding are
  * created lazily the first time [h] is waited on. *)
 let wait_for_work_on_handle h =
-  match HandleMap.find h !work with
-  | exception Not_found ->
-      let cond = Lwt_condition.create () in
-      work := HandleMap.add h cond !work;
-      Lwt_condition.wait cond
-  | cond -> Lwt_condition.wait cond
+  (* We assume [h] is a valid handle (has exactly one bit set) *)
+  let i = flo64 h - 1 in
+  Lwt_condition.wait work.(i)
 
 (* Execute one iteration and register a callback function *)
 let run t =
@@ -59,12 +55,12 @@ let run t =
         (if not (Int64.equal 0L ready_set) then
            (* Some I/O is possible, wake up threads and continue. *)
            let is_in_set set x =
-             not Int64.(equal 0L (logand set (shift_left 1L (to_int x))))
+             not Int64.(equal 0L (logand set (shift_left 1L x)))
            in
-           HandleMap.iter
+           Array.iteri
              (fun k v ->
                if is_in_set ready_set k then Lwt_condition.broadcast v ())
-             !work);
+             work);
         (* Call leave hooks. *)
         Mirage_runtime.run_leave_iter_hooks ();
         aux ()

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -31,7 +31,7 @@ let work = Array.init 64 (fun _ -> Lwt_condition.create ())
  * created lazily the first time [h] is waited on. *)
 let wait_for_work_on_handle h =
   (* We assume [h] is a valid handle (has exactly one bit set) *)
-  let i = flo64 h - 1 in
+  let i = 64 - flo64 h in
   Lwt_condition.wait work.(i)
 
 (* Execute one iteration and register a callback function *)

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -22,7 +22,7 @@
  *)
 
 external solo5_yield : Time.t -> int64 = "mirage_solo5_yield_2"
-external flo64 : int64 -> int = "mirage_flo64"
+external clzll : int64 -> int = "mirage_clzll"
 [@@noalloc]
 
 let work = Array.init 64 (fun _ -> Lwt_condition.create ())
@@ -31,7 +31,7 @@ let work = Array.init 64 (fun _ -> Lwt_condition.create ())
  * created lazily the first time [h] is waited on. *)
 let wait_for_work_on_handle h =
   (* We assume [h] is a valid handle (has exactly one bit set) *)
-  let i = 64 - flo64 h in
+  let i = 64 - clzll h in
   Lwt_condition.wait work.(i)
 
 (* Execute one iteration and register a callback function *)

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -22,8 +22,7 @@
  *)
 
 external solo5_yield : Time.t -> int64 = "mirage_solo5_yield_2"
-external clzll : int64 -> int = "mirage_clzll"
-[@@noalloc]
+external clzll : int64 -> int = "mirage_clzll" [@@noalloc]
 
 let work = Array.init 64 (fun _ -> Lwt_condition.create ())
 


### PR DESCRIPTION
A device handle is a 64 bit number with exactly one bit set. Thus we can have up to 63 devices. We can then use an array instead of a map for the `Lwt_condition.t`s that we use to wait and signal when a device is ready. We also don't "lazily" create `Lwt_condition.t`s anymore, and instead the 64 conditions are created at module initialization (allocation of one block each).

There is an assumption that the `int64`s passed are valid handles. If they are not you may now wait for a valid handle instead of an invalid handle that will never resolve. We could try add a check for that (should it be a runtime error? do we wait indefinitely then?)

I have tested it with just one device. I'm not very confident in bit fiddling, and I'm not sure how portable `__builtin_clzll` is (and we should maybe use `__builtin_ctzll` instead). We should also be able to use an array of length 63 instead of 64, but then I have to think even harder.

I think this won't give us massive performance boost, but since it's at the core of all IO it may be worth it still.